### PR TITLE
When the API returns a 0, fsapi returns None

### DIFF
--- a/fsapi/__init__.py
+++ b/fsapi/__init__.py
@@ -91,7 +91,7 @@ class FSAPI(object):
         if doc is None:
             return None
 
-        return int(doc.value.u8.text) or None
+        return int(doc.value.u8.text)
 
     # returns an int, assuming the value does not exceed 8 bits
     def handle_long(self, item):
@@ -99,7 +99,7 @@ class FSAPI(object):
         if doc is None:
             return None
 
-        return int(doc.value.u32.text) or None
+        return int(doc.value.u32.text)
 
     def handle_list(self, item):
         doc = self.call('LIST_GET_NEXT/'+item+'/-1', dict(

--- a/fsapi/__init__.py
+++ b/fsapi/__init__.py
@@ -239,6 +239,14 @@ class FSAPI(object):
 
     mode = property(get_mode, set_mode)
 
+    def get_position(self):
+        return self.handle_long('netRemote.play.position')
+
+    def set_position(self, value):
+        return self.handle_set('netRemote.play.position', int(value))
+
+    position = property(get_position, set_position)
+
     @property
     def duration(self):
         return self.handle_long('netRemote.play.info.duration')


### PR DESCRIPTION
Fixes an issue where the API was returning numerical value 0 but the library converted it to None